### PR TITLE
put installation steps in right order

### DIFF
--- a/doc/installation-administration-guide.rst
+++ b/doc/installation-administration-guide.rst
@@ -311,14 +311,14 @@ In addition to the *all* option, *install.py* also provides several options that
 process, so you can have more control over it. Concretely, the script provides the following options:
 
 * **clone**: Downloads from GitHub the different components of the Business API Ecosystem
+* **persistence**: Builds persistence.xml files of the different APIs
 * **maven**: Compiles the downloaded APIs using Maven
 * **tables**: Creates the required databases in MySQL
-* **persistence**: Builds persistence.xml files of the different APIs
 * **pools**: Creates database pools in Glassfish
 * **resources**: Creates database resources in Glassfish
 * **redeploy**: Deploys APIs and RSS war files in Glassfish
-* **proxy**: Installs proxy Node libs
 * **charging**: Installs charging Python libs
+* **proxy**: Installs proxy Node libs
 
 Installing the Business API Ecosystem Manually
 ----------------------------------------------


### PR DESCRIPTION
I was having some trouble when installing manually because I did the installation steps in the order of the documentation, which resulted in errors.